### PR TITLE
build(deps): migrate to @fastify/error

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const createError = require('fastify-error')
+const createError = require('@fastify/error')
 
 const errors = {
   /**

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "wait-on": "^6.0.0"
   },
   "dependencies": {
+    "@fastify/error": "^2.0.0",
     "@graphql-tools/wrap": "^8.3.2",
-    "fastify-error": "^1.0.0",
     "fastify-plugin": "^3.0.0",
     "graphql": "^16.2.0"
   },


### PR DESCRIPTION
`fastify-error` has been deprecated as the module has been moved to `@fastify/error`